### PR TITLE
Add Flask backend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # CrisisConnect
+
+CrisisConnect is a prototype web service that helps users locate nearby emergency resources such as shelters, medical centers and food banks.
+
+This repository contains a small Flask application backed by a SQLite database. It demonstrates how SQL can be used to manage resources, reviews and reservations.
+
+## Setup
+
+1. Ensure Python 3 is installed.
+2. Install requirements:
+   ```bash
+   pip install flask
+   ```
+3. Initialize the database and insert sample data:
+   ```bash
+   python3 setup_db.py
+   ```
+4. Start the development server:
+   ```bash
+   python3 app.py
+   ```
+5. The API will be available at `http://localhost:5000`.
+
+## API Endpoints
+
+- `GET /api/resources?zip=<ZIP>&type=<TYPE>&lat=<lat>&lon=<lon>` – list resources filtered by ZIP and type. If latitude and longitude are provided, results are sorted by distance.
+- `POST /api/resources` – create a new resource. JSON body must include fields `name`, `type`, `address`, `zip_code`, `latitude`, `longitude`, `capacity`, and `available`.
+- `PUT /api/resources/<id>` – update an existing resource.
+- `DELETE /api/resources/<id>` – remove a resource.
+- `GET /api/resources/<id>/reviews` – list reviews for a resource.
+- `POST /api/resources/<id>/reviews` – add a new review. JSON body requires `user_id` and `rating`.
+
+## Database Schema
+
+The schema is defined in [`schema.sql`](schema.sql). It includes:
+
+- `users` – application users.
+- `resources` – emergency resource locations.
+- `reviews` – user ratings and comments.
+- `reservations` – tracks reservations of limited resources.
+
+Triggers automatically decrement available spots when a reservation is created and increment when a reservation is removed.
+
+Indexes on ZIP code/type and resource reviews help performance.
+
+## Example Query
+
+```
+curl 'http://localhost:5000/api/resources?zip=94101&type=shelter&lat=37.77&lon=-122.41'
+```
+
+This returns a JSON array of resources ordered by proximity, availability and rating.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,150 @@
+from flask import Flask, request, jsonify, abort
+import sqlite3
+import math
+
+DB_PATH = 'crisisconnect.db'
+
+app = Flask(__name__)
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371  # Earth radius in km
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return R * c
+
+
+@app.route('/api/resources')
+def list_resources():
+    zip_code = request.args.get('zip')
+    r_type = request.args.get('type')
+    lat = request.args.get('lat', type=float)
+    lon = request.args.get('lon', type=float)
+
+    if not zip_code and (lat is None or lon is None):
+        abort(400, 'zip or lat/lon required')
+
+    conn = get_db()
+    cur = conn.cursor()
+    query = "SELECT r.*, IFNULL(avg_rev.avg_rating, 0) AS rating FROM resources r " \
+            "LEFT JOIN (SELECT resource_id, AVG(rating) AS avg_rating FROM reviews GROUP BY resource_id) avg_rev " \
+            "ON r.id = avg_rev.resource_id WHERE 1=1"
+    params = []
+    if zip_code:
+        query += " AND r.zip_code = ?"
+        params.append(zip_code)
+    if r_type:
+        query += " AND r.type = ?"
+        params.append(r_type)
+
+    cur.execute(query, params)
+    resources = []
+    for row in cur.fetchall():
+        distance = None
+        if lat is not None and lon is not None:
+            distance = haversine(lat, lon, row['latitude'], row['longitude'])
+        resources.append({
+            'id': row['id'],
+            'name': row['name'],
+            'type': row['type'],
+            'address': row['address'],
+            'zip_code': row['zip_code'],
+            'capacity': row['capacity'],
+            'available': row['available'],
+            'contact': row['contact'],
+            'rating': row['rating'],
+            'distance_km': distance
+        })
+
+    # sort by distance (if provided), availability desc, rating desc
+    def sort_key(res):
+        return (
+            res['distance_km'] if res['distance_km'] is not None else float('inf'),
+            -res['available'],
+            -res['rating']
+        )
+
+    resources.sort(key=sort_key)
+    return jsonify(resources)
+
+
+@app.route('/api/resources', methods=['POST'])
+def create_resource():
+    data = request.json
+    required = ['name', 'type', 'address', 'zip_code', 'latitude', 'longitude', 'capacity', 'available']
+    if not all(k in data for k in required):
+        abort(400, 'missing fields')
+
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(
+        'INSERT INTO resources (name, type, address, zip_code, latitude, longitude, capacity, available, contact)\n'
+        'VALUES (?,?,?,?,?,?,?,?,?)',
+        (
+            data['name'], data['type'], data['address'], data['zip_code'], data['latitude'],
+            data['longitude'], data['capacity'], data['available'], data.get('contact')
+        )
+    )
+    conn.commit()
+    return jsonify({'id': cur.lastrowid}), 201
+
+
+@app.route('/api/resources/<int:resource_id>', methods=['PUT'])
+def update_resource(resource_id):
+    data = request.json
+    fields = ['name', 'type', 'address', 'zip_code', 'latitude', 'longitude', 'capacity', 'available', 'contact']
+    sets = []
+    values = []
+    for f in fields:
+        if f in data:
+            sets.append(f"{f} = ?")
+            values.append(data[f])
+    if not sets:
+        abort(400, 'no fields to update')
+
+    values.append(resource_id)
+    conn = get_db()
+    conn.execute(f"UPDATE resources SET {', '.join(sets)} WHERE id = ?", values)
+    conn.commit()
+    return '', 204
+
+
+@app.route('/api/resources/<int:resource_id>', methods=['DELETE'])
+def delete_resource(resource_id):
+    conn = get_db()
+    conn.execute('DELETE FROM resources WHERE id = ?', (resource_id,))
+    conn.commit()
+    return '', 204
+
+
+@app.route('/api/resources/<int:resource_id>/reviews')
+def list_reviews(resource_id):
+    conn = get_db()
+    cur = conn.execute('SELECT users.name as user_name, rating, comment, created_at FROM reviews JOIN users ON reviews.user_id = users.id WHERE resource_id = ? ORDER BY created_at DESC', (resource_id,))
+    return jsonify([dict(row) for row in cur.fetchall()])
+
+
+@app.route('/api/resources/<int:resource_id>/reviews', methods=['POST'])
+def add_review(resource_id):
+    data = request.json
+    if not {'user_id', 'rating'} <= data.keys():
+        abort(400, 'user_id and rating required')
+    conn = get_db()
+    conn.execute('INSERT INTO reviews (user_id, resource_id, rating, comment) VALUES (?,?,?,?)',
+                 (data['user_id'], resource_id, data['rating'], data.get('comment')))
+    conn.commit()
+    return '', 201
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,62 @@
+-- Schema for CrisisConnect SQLite database
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS resources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    address TEXT NOT NULL,
+    zip_code TEXT NOT NULL,
+    latitude REAL NOT NULL,
+    longitude REAL NOT NULL,
+    capacity INTEGER NOT NULL,
+    available INTEGER NOT NULL,
+    contact TEXT
+);
+
+CREATE TABLE IF NOT EXISTS reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    resource_id INTEGER NOT NULL,
+    rating INTEGER CHECK(rating >= 1 AND rating <= 5),
+    comment TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(resource_id) REFERENCES resources(id)
+);
+
+CREATE TABLE IF NOT EXISTS reservations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    resource_id INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(resource_id) REFERENCES resources(id)
+);
+
+-- Trigger to reduce availability when a reservation is made
+CREATE TRIGGER IF NOT EXISTS reserve_resource
+AFTER INSERT ON reservations
+BEGIN
+    UPDATE resources SET available = available - 1
+    WHERE id = NEW.resource_id AND available > 0;
+END;
+
+-- Trigger to increase availability when a reservation is cancelled
+CREATE TRIGGER IF NOT EXISTS release_resource
+AFTER DELETE ON reservations
+BEGIN
+    UPDATE resources SET available = available + 1
+    WHERE id = OLD.resource_id;
+END;
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_resources_zip_type ON resources(zip_code, type);
+CREATE INDEX IF NOT EXISTS idx_reviews_resource ON reviews(resource_id);
+

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,0 +1,34 @@
+import sqlite3
+
+DB_PATH = 'crisisconnect.db'
+
+SCHEMA_FILE = 'schema.sql'
+
+SAMPLE_RESOURCES = [
+    ('Central Shelter', 'shelter', '123 Main St', '94101', 37.7749, -122.4194, 50, 50, '555-0100'),
+    ('Downtown Clinic', 'medical', '456 Oak Ave', '94101', 37.7750, -122.4183, 30, 30, '555-0123'),
+    ('City Food Bank', 'food', '789 Pine Rd', '94102', 37.7790, -122.4170, 100, 100, '555-0145')
+]
+
+SAMPLE_USERS = [
+    ('Alice',),
+    ('Bob',)
+]
+
+def main():
+    conn = sqlite3.connect(DB_PATH)
+    with open(SCHEMA_FILE) as f:
+        conn.executescript(f.read())
+
+    cur = conn.cursor()
+    cur.executemany(
+        'INSERT INTO resources (name, type, address, zip_code, latitude, longitude, capacity, available, contact) VALUES (?,?,?,?,?,?,?,?,?)',
+        SAMPLE_RESOURCES
+    )
+    cur.executemany('INSERT INTO users (name) VALUES (?)', SAMPLE_USERS)
+    conn.commit()
+    conn.close()
+    print('Database initialized with sample data.')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create SQLite schema with triggers and indexes
- add sample data initialization script
- implement simple Flask API for resources and reviews
- document setup and endpoints in README

## Testing
- `python3 setup_db.py`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6853996750808327900d651a28d5f184